### PR TITLE
fix: remove jQuery from the global scope

### DIFF
--- a/lib/Citation.js
+++ b/lib/Citation.js
@@ -122,6 +122,7 @@
  *
  */
 
+var jQuery = require("jquery");
 var extend = require('js-extend').extend;
 var Class = require('js-class');
 var Citation;

--- a/lib/CitationList.js
+++ b/lib/CitationList.js
@@ -107,6 +107,7 @@
  *
  */
 
+var jQuery = require("jquery");
 var extend = require('js-extend').extend;
 var Class = require('js-class');
 var CitationList;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,2 @@
-$ = jQuery = require("jquery");
 module.exports.Citation = require("./Citation.js");
 module.exports.CitationList = require("./CitationList.js");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "biojs-vis-pmccitation",
   "description": "For retrieving article metadata from Europe PMC (http://www.europepmc.org). Covers all of PubMed (updated daily) and 3 million full text articles and other sources. A single article or list view can be returned.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "homepage": "https://github.com/ftalo/biojs-vis-pmccitation",
   "author": {
     "name": "Francesco Talo'",


### PR DESCRIPTION
jQuery shouldn't be exposed in the global scope. Otherwise, it may conflict with other version the application is using.